### PR TITLE
fix prevent  extendify to launch demo for demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can take the entire code and adopt it in your plugin, if you wish you.
 
 ## Configuration
 
-You need to set these values in `iwp-hosting-migration.php` file:
+You need to set these values in `iwp-migration-helper.php` file:
 
 1. API Key can be generated from API Token page here - https://app.instawp.io/user/api-tokens, use the read-only + read-write key.
 2. API Domain should be https://app.instawp.io

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ function updateFile(cb) {
                 constant_val = 'https://' + content + '.instawp.io';
             }
 
-            gulp.src('iwp-hosting-migration.php')
+            gulp.src('iwp-migration-helper.php')
                 .pipe(replace(new RegExp(`define\\(\\s*'${constant_key}'\\s*,\\s*'[^']*'\\s*\\)`, 'g'), `define( '${constant_key}', '${constant_val}' )`))
                 .pipe(gulp.dest('./'))
                 .on('end', function () {
@@ -71,7 +71,7 @@ function revertReplacements(cb) {
         let originalValue = originalValues[key];
         promises.push(
             new Promise((resolve, reject) => {
-                gulp.src('iwp-hosting-migration.php')
+                gulp.src('iwp-migration-helper.php')
                     .pipe(replace(new RegExp(`define\\(\\s*'${key}'\\s*,\\s*'[^']*'\\s*\\)`), `define( '${key}', '${originalValue}' )`))
                     .pipe(gulp.dest('./'))
                     .on('end', resolve)
@@ -124,24 +124,24 @@ var zipPath = [
 var potPath = ['./*.php', 'includes/*.php', 'templates/*.php'];
 
 function clean_files() {
-    let cleanPath = ['../iwp-hosting-migration.zip'];
+    let cleanPath = ['../iwp-migration-helper.zip'];
     return del(cleanPath, {force: true});
 }
 
 function create_pot() {
     return gulp.src(potPath)
         .pipe(wpPot({
-            domain: 'iwp-hosting-migration',
+            domain: 'iwp-migration-helper',
             package: 'InstaWP Hosting Migration',
             copyrightText: 'InstaWP',
             ignoreTemplateNameHeader: true
         }))
-        .pipe(gulp.dest('languages/iwp-hosting-migration.pot'));
+        .pipe(gulp.dest('languages/iwp-migration-helper.pot'));
 }
 
 function create_zip() {
     return gulp.src(zipPath, {base: '../'})
-        .pipe(zip('iwp-hosting-migration.zip'))
+        .pipe(zip('iwp-migration-helper.zip'))
         .pipe(gulp.dest('../'))
 }
 

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -26,7 +26,7 @@ class IWP_HOSTING_Ajax {
 		$reset_nonce = isset( $_POST['reset_nonce'] ) ? sanitize_text_field( $_POST['reset_nonce'] ) : '';
 
 		if ( ! wp_verify_nonce( $reset_nonce, 'iwp_reset_plugin' ) ) {
-			wp_send_json_error( [ 'message' => esc_html__( 'Nonce verification failed!', 'iwp-hosting-migration' ) ] );
+			wp_send_json_error( [ 'message' => esc_html__( 'Nonce verification failed!', 'iwp-migration-helper' ) ] );
 		}
 
 		delete_option( 'iwp_demo_site_id' );

--- a/iwp-migration-helper.php
+++ b/iwp-migration-helper.php
@@ -4,7 +4,7 @@
 	Plugin URI: https://instawp.com/hosting-migration/
 	Description: Migration helper plugin for hosting providers.
 	Version: 1.0.6
-	Text Domain: iwp-hosting-migration
+	Text Domain: iwp-migration-helper
 	Author: InstaWP Team
 	Author URI: https://instawp.com/
 	License: GPLv2 or later
@@ -85,9 +85,9 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 			printf( 
 				'<div class="%1$s"><p>%2$s <strong>%3$s</strong> %4$s</p></div>', 
 				'notice notice-warning is-dismissible', 
-				__( 'Missing IWP migration settings. Please check', 'iwp-hosting-migration'),
+				__( 'Missing IWP migration settings. Please check', 'iwp-migration-helper'),
 				'IWP Migration Helper Settings',
-				__( 'plugin is installed, activated and configured properly.', 'iwp-hosting-migration'),
+				__( 'plugin is installed, activated and configured properly.', 'iwp-migration-helper'),
 			);
 		}
 
@@ -104,7 +104,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 			if ( class_exists( 'InstaWP\Connect\Helpers\AutoUpdatePluginFromGitHub' ) ) {
 				$updater = new InstaWP\Connect\Helpers\AutoUpdatePluginFromGitHub(
 					IWP_HOSTING_MIG_PLUGIN_VERSION, // Current version
-					'https://github.com/InstaWP/iwp-hosting-migration', // URL to GitHub repo
+					'https://github.com/InstaWP/iwp-migration-helper', // URL to GitHub repo
 					plugin_basename( __FILE__ ) // Plugin slug
 				);
 			} else {
@@ -132,7 +132,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 
 				wp_send_json_success(
 					array(
-						'message'  => __( 'Plugin activated successfully.', 'iwp-hosting-migration' ),
+						'message'  => __( 'Plugin activated successfully.', 'iwp-migration-helper' ),
 						'response' => $response
 					)
 				);
@@ -146,7 +146,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 				if ( ! $connect_response ) {
 					wp_send_json_error(
 						array(
-							'message'  => __( 'Website could not connect successfully.', 'iwp-hosting-migration' ),
+							'message'  => __( 'Website could not connect successfully.', 'iwp-migration-helper' ),
 							'response' => $connect_response
 						)
 					);
@@ -154,7 +154,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 
 				wp_send_json_success(
 					array(
-						'message'  => __( 'Website connected successfully.', 'iwp-hosting-migration' ),
+						'message'  => __( 'Website connected successfully.', 'iwp-migration-helper' ),
 						'response' => $connect_response
 					)
 				);
@@ -169,7 +169,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 
 				wp_send_json_success(
 					array(
-						'message'      => __( 'Ready to start migration.', 'iwp-hosting-migration' ),
+						'message'      => __( 'Ready to start migration.', 'iwp-migration-helper' ),
 						'response'     => true,
 						'redirect_url' => $this->redirect_url,
 					)
@@ -178,7 +178,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 
 			wp_send_json_error(
 				array(
-					'message'  => __( 'Migration might be finished.', 'iwp-hosting-migration' ),
+					'message'  => __( 'Migration might be finished.', 'iwp-migration-helper' ),
 					'response' => false
 				)
 			);
@@ -194,7 +194,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 			}
 
 			$auto_activate_mig = defined( 'INSTAWP_AUTO_ACTIVATE_MIGRATION' ) && INSTAWP_AUTO_ACTIVATE_MIGRATION;
-			$btn_label         = __( 'Connect', 'iwp-hosting-migration' );
+			$btn_label         = __( 'Connect', 'iwp-migration-helper' );
 			$redirect_url      = '';
 			$classes           = array(
 				'notice',
@@ -203,14 +203,14 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 			);
 
 			if ( ! empty( Helper::get_connect_id() ) ) {
-				$guide_message = __( 'Website is connected.', 'iwp-hosting-migration' );
-				$btn_label     = __( 'Start Migration', 'iwp-hosting-migration' );
+				$guide_message = __( 'Website is connected.', 'iwp-migration-helper' );
+				$btn_label     = __( 'Start Migration', 'iwp-migration-helper' );
 				$classes[]     = 'connected';
 				$redirect_url  = $this->redirect_url;
 			} elseif ( ! function_exists( 'instawp' ) ) {
-				$guide_message = __( 'InstaWP Connect plugin not found.', 'iwp-hosting-migration' );
+				$guide_message = __( 'InstaWP Connect plugin not found.', 'iwp-migration-helper' );
 			} else {
-				$guide_message = __( 'Website is not connected.', 'iwp-hosting-migration' );
+				$guide_message = __( 'Website is not connected.', 'iwp-migration-helper' );
 			}
 
 			if ( $auto_activate_mig ) {
@@ -220,9 +220,9 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 			echo '<div class="' . esc_attr( implode( ' ', $classes ) ) . '">';
 
 			if ( $auto_activate_mig ) {
-				echo '<p>' . __( 'You are being redirected to the site migrator tool..', 'iwp-hosting-migration' ) . '</p>';
+				echo '<p>' . __( 'You are being redirected to the site migrator tool..', 'iwp-migration-helper' ) . '</p>';
 			} else {
-				echo '<p>' . __( 'Your website will be connected with InstaWP and then you can initiate the migration from other website to this website.', 'iwp-hosting-migration' ) . '</p>';
+				echo '<p>' . __( 'Your website will be connected with InstaWP and then you can initiate the migration from other website to this website.', 'iwp-migration-helper' ) . '</p>';
 			}
 
 			echo '<div class="mig-button-wrap">';
@@ -240,8 +240,8 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 
 			$localize_scripts = array(
 				'ajax_url'          => admin_url( 'admin-ajax.php' ),
-				'copy_text'         => __( 'Copied.', 'iwp-hosting-migration' ),
-				'text_transferring' => __( 'Transferring...', 'iwp-hosting-migration' ),
+				'copy_text'         => __( 'Copied.', 'iwp-migration-helper' ),
+				'text_transferring' => __( 'Transferring...', 'iwp-migration-helper' ),
 			);
 
 			if ( defined( 'INSTAWP_AUTO_MIGRATION' ) ) {
@@ -264,7 +264,7 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 		}
 
 		private function set_locale() {
-			load_plugin_textdomain( 'iwp-hosting-migration', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+			load_plugin_textdomain( 'iwp-migration-helper', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 		}
 	}
 }

--- a/iwp-migration-helper.php
+++ b/iwp-migration-helper.php
@@ -60,16 +60,16 @@ if ( ! class_exists( 'IWP_HOSTING_MIG_Main' ) ) {
 		 */
 		public function check_site_demo() {
 			if ( class_exists('Extendify') || class_exists('ExtendifySdk') ) {
-				// Prevent 
-				if( ! get_option( 'extendify_launch_loaded', false ) ) {
-					$iwp_demo_site_id = get_option( 'iwp_demo_site_id' );
-					if( ! empty( $iwp_demo_site_id ) ) {
+				// Prevent launch onboarding if its a demo site
+				$iwp_demo_site_id = get_option( 'iwp_demo_site_id' );
+				if( ! empty( $iwp_demo_site_id ) ) {
+					if( ! get_option( 'extendify_launch_loaded', false ) ) {
 						// extendify/src/Launch/LaunchPage.jsx
 						$date = new DateTime();
 						$date = $date->format('Y-m-d\TH:i:s.v\Z'); // toISOString
 						\update_option( 'extendify_launch_loaded', $date );
 						\update_option( 'extendify_attempted_redirect_count', 1 );
-            			\update_option( 'extendify_attempted_redirect', gmdate('Y-m-d H:i:s') );
+						\update_option( 'extendify_attempted_redirect', gmdate('Y-m-d H:i:s') );
 					}
 				}
 			}

--- a/languages/iwp-migration-helper.pot
+++ b/languages/iwp-migration-helper.pot
@@ -5,7 +5,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-10-17 08:58+0000\n"
+"POT-Creation-Date: 2024-11-26 10:48+0000\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
 "X-Poedit-SearchPath-0: .\n"
@@ -17,59 +17,67 @@ msgstr ""
 msgid "Nonce verification failed!"
 msgstr ""
 
-#: iwp-hosting-migration.php:97
+#: iwp-migration-helper.php:88
+msgid "Missing IWP migration settings. Please check"
+msgstr ""
+
+#: iwp-migration-helper.php:90
+msgid "plugin is installed, activated and configured properly."
+msgstr ""
+
+#: iwp-migration-helper.php:135
 msgid "Plugin activated successfully."
 msgstr ""
 
-#: iwp-hosting-migration.php:111
+#: iwp-migration-helper.php:149
 msgid "Website could not connect successfully."
 msgstr ""
 
-#: iwp-hosting-migration.php:119
+#: iwp-migration-helper.php:157
 msgid "Website connected successfully."
 msgstr ""
 
-#: iwp-hosting-migration.php:134
+#: iwp-migration-helper.php:172
 msgid "Ready to start migration."
 msgstr ""
 
-#: iwp-hosting-migration.php:143
+#: iwp-migration-helper.php:181
 msgid "Migration might be finished."
 msgstr ""
 
-#: iwp-hosting-migration.php:159
+#: iwp-migration-helper.php:197
 msgid "Connect"
 msgstr ""
 
-#: iwp-hosting-migration.php:175
+#: iwp-migration-helper.php:213
 msgid "Website is not connected."
 msgstr ""
 
-#: iwp-hosting-migration.php:173
+#: iwp-migration-helper.php:211
 msgid "InstaWP Connect plugin not found."
 msgstr ""
 
-#: iwp-hosting-migration.php:168
+#: iwp-migration-helper.php:206
 msgid "Website is connected."
 msgstr ""
 
-#: iwp-hosting-migration.php:169
+#: iwp-migration-helper.php:207
 msgid "Start Migration"
 msgstr ""
 
-#: iwp-hosting-migration.php:187
+#: iwp-migration-helper.php:225
 msgid "Your website will be connected with InstaWP and then you can initiate the migration from other website to this website."
 msgstr ""
 
-#: iwp-hosting-migration.php:185
+#: iwp-migration-helper.php:223
 msgid "You are being redirected to the site migrator tool.."
 msgstr ""
 
-#: iwp-hosting-migration.php:205
+#: iwp-migration-helper.php:243
 msgid "Copied."
 msgstr ""
 
-#: iwp-hosting-migration.php:206
+#: iwp-migration-helper.php:244
 msgid "Transferring..."
 msgstr ""
 

--- a/languages/iwp-migration-helper.pot
+++ b/languages/iwp-migration-helper.pot
@@ -5,7 +5,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-11-26 10:48+0000\n"
+"POT-Creation-Date: 2024-12-02 06:37+0000\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
 "X-Poedit-SearchPath-0: .\n"
@@ -17,67 +17,67 @@ msgstr ""
 msgid "Nonce verification failed!"
 msgstr ""
 
-#: iwp-migration-helper.php:88
+#: iwp-migration-helper.php:93
 msgid "Missing IWP migration settings. Please check"
 msgstr ""
 
-#: iwp-migration-helper.php:90
+#: iwp-migration-helper.php:95
 msgid "plugin is installed, activated and configured properly."
 msgstr ""
 
-#: iwp-migration-helper.php:135
+#: iwp-migration-helper.php:140
 msgid "Plugin activated successfully."
 msgstr ""
 
-#: iwp-migration-helper.php:149
+#: iwp-migration-helper.php:154
 msgid "Website could not connect successfully."
 msgstr ""
 
-#: iwp-migration-helper.php:157
+#: iwp-migration-helper.php:162
 msgid "Website connected successfully."
 msgstr ""
 
-#: iwp-migration-helper.php:172
+#: iwp-migration-helper.php:177
 msgid "Ready to start migration."
 msgstr ""
 
-#: iwp-migration-helper.php:181
+#: iwp-migration-helper.php:186
 msgid "Migration might be finished."
 msgstr ""
 
-#: iwp-migration-helper.php:197
+#: iwp-migration-helper.php:202
 msgid "Connect"
 msgstr ""
 
-#: iwp-migration-helper.php:213
+#: iwp-migration-helper.php:218
 msgid "Website is not connected."
 msgstr ""
 
-#: iwp-migration-helper.php:211
+#: iwp-migration-helper.php:216
 msgid "InstaWP Connect plugin not found."
 msgstr ""
 
-#: iwp-migration-helper.php:206
+#: iwp-migration-helper.php:211
 msgid "Website is connected."
 msgstr ""
 
-#: iwp-migration-helper.php:207
+#: iwp-migration-helper.php:212
 msgid "Start Migration"
 msgstr ""
 
-#: iwp-migration-helper.php:225
+#: iwp-migration-helper.php:230
 msgid "Your website will be connected with InstaWP and then you can initiate the migration from other website to this website."
 msgstr ""
 
-#: iwp-migration-helper.php:223
+#: iwp-migration-helper.php:228
 msgid "You are being redirected to the site migrator tool.."
 msgstr ""
 
-#: iwp-migration-helper.php:243
+#: iwp-migration-helper.php:251
 msgid "Copied."
 msgstr ""
 
-#: iwp-migration-helper.php:244
+#: iwp-migration-helper.php:252
 msgid "Transferring..."
 msgstr ""
 

--- a/templates/auto-migration.php
+++ b/templates/auto-migration.php
@@ -26,19 +26,19 @@ if ( ! empty( $iwp_demo_site_url ) ) {
 
 	$iwp_demo_created_at_str = $date->format( 'jS M Y, g:i a' );
 	$iwp_am_settings         = defined( 'IWP_AM_SETTINGS' ) ? json_decode( IWP_AM_SETTINGS ) : (object) [];
-	$iwp_text_heading        = isset( $iwp_am_settings->text_heading ) ? __( $iwp_am_settings->text_heading, 'iwp-hosting-migration' ) : __( 'We have detected a website <span>{demo_site_url}</span> which you used to create a demo site at {demo_created_at}.', 'iwp-hosting-migration' );
+	$iwp_text_heading        = isset( $iwp_am_settings->text_heading ) ? __( $iwp_am_settings->text_heading, 'iwp-migration-helper' ) : __( 'We have detected a website <span>{demo_site_url}</span> which you used to create a demo site at {demo_created_at}.', 'iwp-migration-helper' );
 	$iwp_text_heading        = str_replace( array( "{demo_site_url}", "{demo_created_at}" ), array( $iwp_demo_site_url, $iwp_demo_created_at_str ), $iwp_text_heading );
-	$iwp_text_description    = $iwp_am_settings->text_desc ?? esc_html__( 'Transfer or Migrate the site here.', 'iwp-hosting-migration' );
+	$iwp_text_description    = $iwp_am_settings->text_desc ?? esc_html__( 'Transfer or Migrate the site here.', 'iwp-migration-helper' );
 } else {
-	$iwp_text_heading     = esc_html__( 'We could not found any website to migration!', 'iwp-hosting-migration' );
-	$iwp_text_description = esc_html__( 'Please try again with the reset button.', 'iwp-hosting-migration' );
+	$iwp_text_heading     = esc_html__( 'We could not found any website to migration!', 'iwp-migration-helper' );
+	$iwp_text_description = esc_html__( 'Please try again with the reset button.', 'iwp-migration-helper' );
 	$wrapper_classes[]    = 'no-website-found';
 }
 
 ?>
 
 <div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>">
-    <span class="iwp-reset" data-reset-nonce="<?php echo wp_create_nonce( 'iwp_reset_plugin' ); ?>"><?php esc_html_e( 'Reset', 'iwp-hosting-migration' ); ?></span>
+    <span class="iwp-reset" data-reset-nonce="<?php echo wp_create_nonce( 'iwp_reset_plugin' ); ?>"><?php esc_html_e( 'Reset', 'iwp-migration-helper' ); ?></span>
 
 	<?php printf( '<h3 class="iwp-text-header">%s</h3>', $iwp_text_heading ); ?>
 
@@ -49,7 +49,7 @@ if ( ! empty( $iwp_demo_site_url ) ) {
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M1.33301 1.33398V5.50065H1.81761M14.6148 7.16732C14.2047 3.87872 11.3994 1.33398 7.99967 1.33398C5.20186 1.33398 2.80658 3.05746 1.81761 5.50065M1.81761 5.50065H5.49967M14.6663 14.6673V10.5007H14.1817M14.1817 10.5007C13.1928 12.9438 10.7975 14.6673 7.99967 14.6673C4.59999 14.6673 1.79467 12.1226 1.38459 8.83398M14.1817 10.5007H10.4997" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <span><?php esc_attr_e( 'Transfer Site', 'iwp-hosting-migration' ); ?></span>
+            <span><?php esc_attr_e( 'Transfer Site', 'iwp-migration-helper' ); ?></span>
         </button>
 	<?php endif; ?>
 


### PR DESCRIPTION
1. Load plugin class on 'plugin_loaded' hook so that it can get demo settings constants
2. Add Admin notice for IWP migration settings 
![Screenshot 2024-11-26 163434](https://github.com/user-attachments/assets/b0641da0-850e-4da5-8c29-718156e97f4d)

3. fix prevent  Extendify to launch demo for demo site
4. Correct text domain 'iwp-hosting-migartion' to 'iwp-migration-helper'